### PR TITLE
Fixed the typo in contact email

### DIFF
--- a/utils/constant.ts
+++ b/utils/constant.ts
@@ -25,4 +25,4 @@ export const APP_IMAGE_EXTENSION_DOCS_FIX = '-linux-x86_64.AppImage';
 
 export const DMG_EXTENSION_DOCS_FIX_64 = '-mac-x64.dmg';
 
-export const ARCHIFILTRE_MAIL_ADDRESS = 'archifiltre@fabrique.socia.gouv.fr';
+export const ARCHIFILTRE_MAIL_ADDRESS = 'archifiltre@fabrique.social.gouv.fr';


### PR DESCRIPTION
Il manquait un l à social dans l'adresse de contact